### PR TITLE
Touch command

### DIFF
--- a/tofino_test_builds/19_touch.test/codegen.py
+++ b/tofino_test_builds/19_touch.test/codegen.py
@@ -1,0 +1,25 @@
+import sys
+
+sys.path.append("../../src/")
+
+from p4rrot.generator_tools import *
+from p4rrot.known_types import *
+from p4rrot.core.commands import *
+from p4rrot.tofino.commands import *
+from p4rrot.tofino.stateful import *
+from p4rrot.standard_fields import *
+
+UID.reset()
+
+fp = FlowProcessor(
+        istruct = [('x',uint32_t)],
+    )
+
+fp.add(Touch('x'))
+  
+fs = FlowSelector("IPV4_UDP", [], fp)
+
+solution = Solution()
+solution.add_flow_processor(fp)
+solution.add_flow_selector(fs)
+solution.get_generated_code().dump("result.p4app")

--- a/tofino_test_builds/19_touch.test/test.p4app/a_apply.p4
+++ b/tofino_test_builds/19_touch.test/test.p4app/a_apply.p4
@@ -1,0 +1,5 @@
+if (hdr.genhdr_uid1.isValid()){
+	#define OUTPUT_HEADER_SIZE 4
+	touch_x_uid2.apply();
+	#undef OUTPUT_HEADER_SIZE
+}

--- a/tofino_test_builds/19_touch.test/test.p4app/a_chains.p4
+++ b/tofino_test_builds/19_touch.test/test.p4app/a_chains.p4
@@ -1,0 +1,11 @@
+state parse_genhdr_uid1{
+	pkt.extract(hdr.genhdr_uid1);
+	transition accept;
+}
+state check_uid4{
+	transition parse_genhdr_uid1;
+}
+#define CHAIN_IPV4_UDP
+state chain_ipv4_udp{
+	transition check_uid4;
+}

--- a/tofino_test_builds/19_touch.test/test.p4app/a_declarations.p4
+++ b/tofino_test_builds/19_touch.test/test.p4app/a_declarations.p4
@@ -1,0 +1,6 @@
+action never_call_uid3(bit<32> x){ hdr.genhdr_uid1.x = x; }
+table touch_x_uid2{
+	key = { hdr.genhdr_uid1.x: exact; }
+	actions = { never_call_uid3; NoAction; }
+	const default_action = NoAction;
+}

--- a/tofino_test_builds/19_touch.test/test.p4app/a_hdrlist.p4
+++ b/tofino_test_builds/19_touch.test/test.p4app/a_hdrlist.p4
@@ -1,0 +1,1 @@
+genhdr_uid1_h genhdr_uid1;

--- a/tofino_test_builds/19_touch.test/test.p4app/a_headers.p4
+++ b/tofino_test_builds/19_touch.test/test.p4app/a_headers.p4
@@ -1,0 +1,3 @@
+header genhdr_uid1_h{
+	bit<32> x;
+}


### PR DESCRIPTION
The Touch command pretends to update a variable but never changes its value. 
(It can be used to trick the compiler if needed.)