### PR TITLE
Fix CP set sizes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: [ '3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/examples/ntp_guard/codegen.py
+++ b/examples/ntp_guard/codegen.py
@@ -29,7 +29,7 @@ fp = FlowProcessor(
 )
 (
 fp
-.add(CheckControlPlaneSet(["origin_timestamp"], "exploit"))
+.add(CheckControlPlaneSet(["origin_timestamp"], "exploit", size=1))
 .add(If("exploit"))
 .add(DropPacket())
 .EndIf()

--- a/src/p4rrot/core/commands.py
+++ b/src/p4rrot/core/commands.py
@@ -906,10 +906,11 @@ class Table:
         return gc
 
 class ReadFromControlPlaneSet(Command):
-    def __init__(self, keys, targets, env=None):
+    def __init__(self, keys, targets,size=256, env=None):
         self.targets = targets
         self.keys = keys
         self.env = env
+        self.size = size
 
     def get_generated_code(self):
         gc = GeneratedCode()
@@ -941,10 +942,10 @@ class ReadFromControlPlaneSet(Command):
             key = [
                 {"name": part_key[0].get_handle(), "match_type": part_key[1]} for part_key in match
             ]
-        size = 1
+        
         const_entries = []
         eval_table = Table(
-            table_name, actions, key, size, const_entries
+            table_name, actions, key, self.size, const_entries
         )
         gc.concat(eval_table.get_generated_code())
         apply.writeln("{}.apply();".format(table_name))

--- a/src/p4rrot/tofino/commands.py
+++ b/src/p4rrot/tofino/commands.py
@@ -707,8 +707,9 @@ class Digest(Command):
 
 
 class CheckControlPlaneSet(Command):
-    def __init__(self, keys, target, table_name = None, env=None):
+    def __init__(self, keys, target, size=256, table_name = None, env=None):
         self.target = target
+        self.size = size
         self.keys = keys
         self.table_name = table_name
         self.env = env
@@ -740,11 +741,11 @@ class CheckControlPlaneSet(Command):
             key = [
                 {"name": part_key.get_handle(), "match_type": "exact"} for part_key in match
             ]
-        size = 1
+            
         const_entries = []
         default_action = setter_action + "_false"
         eval_table = Table(
-            table_name, actions, key, size, const_entries, default_action
+            table_name, actions, key, self.size, const_entries, default_action
         )
         gc.concat(eval_table.get_generated_code())
         apply.writeln("{}.apply();".format(table_name))

--- a/src/p4rrot/tofino/commands.py
+++ b/src/p4rrot/tofino/commands.py
@@ -741,7 +741,7 @@ class CheckControlPlaneSet(Command):
             key = [
                 {"name": part_key.get_handle(), "match_type": "exact"} for part_key in match
             ]
-            
+
         const_entries = []
         default_action = setter_action + "_false"
         eval_table = Table(
@@ -758,10 +758,11 @@ class CheckControlPlaneSet(Command):
         pass
 
 class ReadFromControlPlaneSet(Command):
-    def __init__(self, keys, targets, env=None):
+    def __init__(self, keys, targets, size=256, env=None):
         self.targets = targets
         self.keys = keys
         self.env = env
+        self.size = size
 
     def get_generated_code(self):
         gc = GeneratedCode()
@@ -793,10 +794,10 @@ class ReadFromControlPlaneSet(Command):
             key = [
                 {"name": part_key.get_handle(), "match_type": "exact"} for part_key in match
             ]
-        size = 1
+            
         const_entries = []
         eval_table = Table(
-            table_name, actions, key, size, const_entries
+            table_name, actions, key, self.size, const_entries
         )
         gc.concat(eval_table.get_generated_code())
         apply.writeln("{}.apply();".format(table_name))

--- a/tests/tofino/test_tofino_commands.py
+++ b/tests/tofino/test_tofino_commands.py
@@ -473,7 +473,7 @@ def test_check_control_plane_set():
         None,
     )
     check_control_plane_set = CheckControlPlaneSet(
-        ["hdr.ipv4.src", "hdr.udp.srcPort"], "allowed", None, env
+        ["hdr.ipv4.src", "hdr.udp.srcPort"], "allowed", size=1, env=env
     )
     gc = check_control_plane_set.get_generated_code()
     generated_decl = gc.get_decl().get_code().strip().split("\n")

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 minversion = 3.8.0
-envlist = py36, py37, py38, py39
+envlist = py37, py38, py39
 isolated_build = true
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
This pull request allows us to define the size of the tables generated by the *ControlPlaneSet commands.
(Python 3.6 is also removed from the tests since it is not supported anymore.)